### PR TITLE
Additions/Alterations to allow pagination scraping of TicketMaster API

### DIFF
--- a/scripts/ticketmaster-API.py
+++ b/scripts/ticketmaster-API.py
@@ -17,63 +17,96 @@ cursor = db.cursor()
 
 URL = "https://app.ticketmaster.com/discovery/v2/events.json"
 
-us_states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE",
-             "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS",
-             "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS",
-             "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY",
-             "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
-             "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY"]
+us_states = [#"AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE",
+             #"FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS",
+             #"KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS",
+             #"MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY",
+             #"NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+             #"SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI",
+             "NY"]
 
 apikey = "sDeUMZRAoiaKBkELqJqSCS2phLMxJj4A"
+#apikey2 = "s10q0X1HOmg4rgAtNS5wuhgekEcFaGYC"
 classificationName = "music"
+size = 200
 
 for us_state in us_states:
     params = {'stateCode': us_state,
               'classificationName': classificationName,
               'apikey': apikey,
-              'startEndDateTime': ['2018-01-01T00:00:00Z',
-                                   '2018-12-31T23:59:59Z']}
+              'startEndDateTime': ['2019-05-01T00:00:00Z',
+                                   '2019-05-31T23:59:59Z'],
+              'size': size}
 
     r = requests.get(url=URL, params=params)
 
     data = r.json()
 
-    events = data['_embedded']['events']
+    pages_num = data['page']['totalPages']
+    if pages_num == 1:
+        pages_list = [0]
+    else:
+        pages_list = range(0,pages_num-1)
 
-    for index, event in enumerate(events):
-        local_date = event['dates']['start']['localDate']
-        event_id = event['id']
+    #print(us_state)
+    #print(pages_num)
 
-        main_genre = event['classifications'][0].get('genre')
-        main_genre_name = main_genre['name'] if main_genre else ''
-        sub_genre = event['classifications'][0].get('subGenre')
-        sub_genre_name = sub_genre['name'] if sub_genre else ''
+    entry = 1
 
-        main_venue = event['_embedded']['venues'][0]
-        main_venue_name = main_venue['name']
+    for page in pages_list:
+        params = {'stateCode': us_state,
+                  'classificationName': classificationName,
+                  'apikey': apikey,
+                  'startEndDateTime': ['2019-05-01T00:00:00Z',
+                                       '2019-05-31T23:59:59Z'],
+                  'size': size,
+                  'page': page
+                  }
 
-        main_venue_location = main_venue.get('location')
-        main_venue_lat = main_venue['location'][
-            'latitude'] if main_venue_location else None
-        main_venue_lon = main_venue['location'][
-            'longitude'] if main_venue_location else None
+        r = requests.get(url=URL, params=params)
 
-        artists = event['_embedded'].get('attractions')
-        main_artist_id = artists[0]['id'] if artists else ''
-        main_artist_name = artists[0]['name'] if artists else ''
-        main_artist_genre = artists[0]['classifications'][
-            0]['genre']['name'] if artists else ''
+        data = r.json()
 
-        query = """INSERT INTO ticketmaster_events
-                    (ticketmaster_id, local_date, event_genre,
-                    event_subgenre, venue, venue_lat, venue_long,
-                    artist_id, artist_name, artist_genre) VALUES
-                    (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
-        values = (event_id, local_date, main_genre_name, sub_genre_name,
-                  main_venue_name, main_venue_lat, main_venue_lon,
-                  main_artist_id, main_artist_name, main_artist_genre)
+        events = data['_embedded']['events']
 
-        cursor.execute(query, values)
-        db.commit()
+        #print(us_state,page)
 
-    time.sleep(1)
+        for index, event in enumerate(events):
+            local_date = event['dates']['start']['localDate']
+            event_id = event['id']
+
+            main_genre = event['classifications'][0].get('genre')
+            main_genre_name = main_genre['name'] if main_genre else ''
+            sub_genre = event['classifications'][0].get('subGenre')
+            sub_genre_name = sub_genre['name'] if sub_genre else ''
+
+            main_venue = event['_embedded']['venues'][0]
+            main_venue_name = main_venue['name']
+
+            main_venue_location = main_venue.get('location')
+            main_venue_lat = main_venue['location'][
+                'latitude'] if main_venue_location else None
+            main_venue_lon = main_venue['location'][
+                'longitude'] if main_venue_location else None
+
+            artists = event['_embedded'].get('attractions')
+            main_artist_id = artists[0]['id'] if artists else ''
+            try:main_artist_name = artists[0]['name'] if artists else ''
+            except: main_artist_name = ''
+            try: main_artist_genre = artists[0]['classifications'][0]['genre']['name'] if artists else ''
+            except: main_artist_genre = ''
+
+            query = """INSERT INTO ticketmaster_events
+                        (ticketmaster_id, local_date, event_genre,
+                        event_subgenre, venue, venue_lat, venue_long,
+                        artist_id, artist_name, artist_genre) VALUES
+                        (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
+            values = (event_id, local_date, main_genre_name, sub_genre_name,
+                      main_venue_name, main_venue_lat, main_venue_lon,
+                      main_artist_id, main_artist_name, main_artist_genre)
+
+            cursor.execute(query, values)
+            db.commit()
+            print("page",page,"   ","entry",entry,"   ","artist",main_artist_name)
+            entry = entry + 1
+        time.sleep(1)

--- a/scripts/ticketmaster-API.py
+++ b/scripts/ticketmaster-API.py
@@ -2,6 +2,7 @@ import requests
 import time
 import mysql.connector as mysql
 import configparser
+import datetime
 
 config = configparser.ConfigParser()
 config.read('../config.ini')
@@ -17,7 +18,8 @@ cursor = db.cursor()
 
 URL = "https://app.ticketmaster.com/discovery/v2/events.json"
 
-us_states = [#"AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE",
+us_states = [
+             #"AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE",
              #"FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS",
              #"KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS",
              #"MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY",
@@ -30,69 +32,67 @@ size = 200
 apikey = config['ticketmaster']['apikey']
 apikey2 = config['ticketmaster']['apikey2']
 
+start_date = datetime.datetime.today()
+date_range = [start_date + datetime.timedelta(days=x) for x in range(0, 30)]
+date_list = list()
+for i in date_range:
+    date_list.append([(str(i)[:10]+"T00:00:00Z"),(str(i)[:10]+"T23:59:59Z")])
+
+
 for us_state in us_states:
-    params = {'stateCode': us_state,
-              'classificationName': classificationName,
-              'apikey': apikey,
-              'startEndDateTime': ['2019-05-02T00:00:00Z',
-                                   '2019-06-01T23:59:59Z'],
-              'size': size}
 
-    r = requests.get(url=URL, params=params)
+    for date in date_list:
+        time.sleep(.21)
 
-    data = r.json()
-
-    pages_num = data['page']['totalPages']
-    pages_list = range(0,pages_num-1) if pages_num > 1 else [0]
-
-    for page in pages_list:
         params = {'stateCode': us_state,
                   'classificationName': classificationName,
                   'apikey': apikey,
-                  'startEndDateTime': ['2019-05-02T00:00:00Z',
-                                       '2019-06-01T23:59:59Z'],
-                  'size': size,
-                  'page': page
+                  'startDateTime': date[0],
+                  'endDateTime': date[1],
+                  'size': size
                   }
-
         r = requests.get(url=URL, params=params)
-
         data = r.json()
 
-        events = data['_embedded']['events']
+        total_events = data['page']['totalElements']
 
-        for index, event in enumerate(events):
-            local_date = event['dates']['start']['localDate']
-            event_id = event['id']
+        if total_events > 0 :
+            events = data['_embedded']['events']
 
-            main_genre = event['classifications'][0].get('genre')
-            main_genre_name = main_genre['name'] if main_genre else ''
-            sub_genre = event['classifications'][0].get('subGenre')
-            sub_genre_name = sub_genre['name'] if sub_genre else ''
+            for index, event in enumerate(events):
+                local_date = event['dates']['start']['localDate']
+                event_id = event['id']
 
-            main_venue = event['_embedded']['venues'][0]
-            main_venue_name = main_venue['name']
+                main_genre = event['classifications'][0].get('genre')
+                main_genre_name = main_genre['name'] if main_genre else ''
+                sub_genre = event['classifications'][0].get('subGenre')
+                sub_genre_name = sub_genre['name'] if sub_genre else ''
 
-            main_venue_location = main_venue.get('location')
-            main_venue_lat = main_venue['location'][
-                'latitude'] if main_venue_location else None
-            main_venue_lon = main_venue['location'][
-                'longitude'] if main_venue_location else None
+                main_venue = event['_embedded']['venues'][0]
+                main_venue_name = main_venue['name']
 
-            artists = event['_embedded'].get('attractions')
-            main_artist_id = artists[0]['id'] if artists else ''
-            main_artist_name = artists[0]['name'] if artists is not None and 'name' in artists[0] else ''
-            main_artist_genre = artists[0]['classifications'][0]['genre']['name'] if artists is not None and 'classifications' in artists[0] else ''
+                main_venue_location = main_venue.get('location')
+                main_venue_lat = main_venue['location'][
+                    'latitude'] if main_venue_location else None
+                main_venue_lon = main_venue['location'][
+                    'longitude'] if main_venue_location else None
 
-            query = """INSERT INTO ticketmaster_events
-                        (ticketmaster_id, local_date, event_genre,
-                        event_subgenre, venue, venue_lat, venue_long,
-                        artist_id, artist_name, artist_genre) VALUES
-                        (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
-            values = (event_id, local_date, main_genre_name, sub_genre_name,
-                      main_venue_name, main_venue_lat, main_venue_lon,
-                      main_artist_id, main_artist_name, main_artist_genre)
+                artists = event['_embedded'].get('attractions')
+                main_artist_id = artists[0]['id'] if artists else ''
+                main_artist_name = artists[0]['name'] if (artists is not None and
+                  'name' in artists[0]) else ''
+                main_artist_genre = artists[0]['classifications'][0]['genre'][
+                  'name'] if artists is not None and 'classifications' in artists[
+                  0] and 'genre' in artists[0]['classifications'][0] else ''
 
-            cursor.execute(query, values)
-            db.commit()
-        time.sleep(1)
+                query = """INSERT INTO ticketmaster_events
+                            (ticketmaster_id, local_date, event_genre,
+                            event_subgenre, venue, venue_lat, venue_long,
+                            artist_id, artist_name, artist_genre) VALUES
+                            (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
+                values = (event_id, local_date, main_genre_name, sub_genre_name,
+                          main_venue_name, main_venue_lat, main_venue_lon,
+                          main_artist_id, main_artist_name, main_artist_genre)
+
+                cursor.execute(query, values)
+                db.commit()

--- a/scripts/ticketmaster-API.py
+++ b/scripts/ticketmaster-API.py
@@ -24,18 +24,18 @@ us_states = [
              "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS",
              "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY",
              "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
-             "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI"]
+             "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WI",
+             "WV", "WY"
+             ]
 
 classificationName = "music"
 size = 200
 apikey = config['ticketmaster']['apikey']
-apikey2 = config['ticketmaster']['apikey2']
 
 start_date = datetime.datetime.today()
 date_range = [start_date + datetime.timedelta(days=x) for x in range(0, 30)]
-date_list = list()
-for i in date_range:
-    date_list.append([(str(i)[:10]+"T00:00:00Z"),(str(i)[:10]+"T23:59:59Z")])
+date_list = list(map(lambda x: [x.strftime("%Y-%m-%d"+"T00:00:00Z"),x.strftime(
+    "%Y-%m-%d"+"T23:59:59Z")],date_range))
 
 
 for us_state in us_states:
@@ -78,11 +78,11 @@ for us_state in us_states:
 
                 artists = event['_embedded'].get('attractions')
                 main_artist_id = artists[0]['id'] if artists else ''
-                main_artist_name = artists[0]['name'] if (artists is not None and
-                  'name' in artists[0]) else ''
+                main_artist_name = artists[0]['name'] if (artists and 'name' in
+                    artists[0]) else ''
                 main_artist_genre = artists[0]['classifications'][0]['genre'][
-                  'name'] if artists is not None and 'classifications' in artists[
-                  0] and 'genre' in artists[0]['classifications'][0] else ''
+                  'name'] if (artists and 'classifications' in artists[
+                  0] and 'genre' in artists[0]['classifications'][0]) else ''
 
                 query = """INSERT INTO ticketmaster_events
                             (ticketmaster_id, local_date, event_genre,

--- a/scripts/ticketmaster-API.py
+++ b/scripts/ticketmaster-API.py
@@ -19,13 +19,12 @@ cursor = db.cursor()
 URL = "https://app.ticketmaster.com/discovery/v2/events.json"
 
 us_states = [
-             #"AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE",
-             #"FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS",
-             #"KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS",
-             #"MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY",
-             #"NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
-             #"SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI",
-             "DE"]
+             "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE",
+             "FL", "GA", "HI", "ID", "IL", "IN", "IA", "KS",
+             "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS",
+             "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY",
+             "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+             "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI"]
 
 classificationName = "music"
 size = 200


### PR DESCRIPTION
1) commented out all states other than NY, since this is the one giving us problems
2) added a second apikey in case the first reaches its limit; commented out
3) added page size parameter var "size"
4) created a pages_list that is 0 if there there is only one page, and 0 to pages_num - 1, otherwise
5) implemented a for-loop to iterate through each page in pages_list
6) added two try-except procedures to gracefully catch when ['name'] and ['classification'] keys are not in the 'artists' dict; both fields are set to empty strings ('') if nonexistent
7) added an entry var capturing how many entries have been added to the db.
8) after each entry is added to the db a message prints which page of page_list the for-loop is on, the number of the entry added, and the artist_name of that entry
9) changed the date parameter to span May 2019
10) I probably missing something, but I think I got most of the significant additions/changes

I had to also change the lengths of some fields in SQL to get the script to run--sending a pic through whatsapp