### PR TITLE
Moving popup to fixed div for Leaflet map only

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -109,7 +109,6 @@ html, body, {
 #tooltip {
   position: absolute;
   text-align: center;
-  padding: 20px;
   margin: 10px;
   font: 12px sans-serif;
   border-radius: 2px;
@@ -122,12 +121,20 @@ html, body, {
   opacity: 0;
 }
 
-.custom .leaflet-popup-tip,
+
 .custom .leaflet-popup-content-wrapper {
 
     text-align: center;
-    background: rgba(0, 0, 0, 0.7);
-    color: white;
+    background: rgba(255, 255, 255, 0.8);
+    color: black;
+	margin: 0px;
+	padding: 0px;
+}
+
+.custom .leaflet-popup-tip
+{
+	margin: 0px;
+	padding: 0px;
 }
 
 #tooltip h4, .custom .leaflet-popup-content-wrapper h4 {
@@ -155,7 +162,7 @@ html, body, {
   text-align: center;
 }
 
-/* Next two entries are for the colouring of the info text box*/
+/* Next two entries are for the colouring of the left column text box*/
 
 :root {
   --displayInfo-color: #888b94;
@@ -165,4 +172,25 @@ html, body, {
 #displayInfo {
 	background-color: var(--displayInfo-color);
 	color: var(--displayInfo-text-color);
+}
+
+/* Next two entries are for the colouring of the on-map info box*/
+
+.info {
+    padding: 6px 8px;
+    background: rgba(0, 0, 0, 0.9);
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    border-radius: 5px;
+	text-align: right;
+    min-width: 200px;
+    background: rgba(0, 0, 0, 0.9);
+    border-radius: 5px;
+    font-size: 15px;
+    color: white;
+    opacity: 0.8;
+}
+
+.info h4 {
+    margin: 0 0 5px;
+    color: white;
 }

--- a/static/js/uStates.js
+++ b/static/js/uStates.js
@@ -90,8 +90,7 @@ uStates.draw = function(genre) {
               "</table>" +
               "<small>(click to zoom)</small>")
             .style("left", (d3.event.pageX - 345) + "px")
-            .style("top", (d3.event.pageY - 120) + "px");
-
+            .style("top", (d3.event.pageY - 100) + "px");
         }
 
         //tooltip for all genres
@@ -106,7 +105,7 @@ uStates.draw = function(genre) {
               "</table>" +
               "<small>(click to zoom)</small>")
             .style("left", (d3.event.pageX - 345) + "px")
-            .style("top", (d3.event.pageY - 120) + "px");
+            .style("top", (d3.event.pageY - 100) + "px");
         }
 
         function mouseOut() {

--- a/static/js/usCounties.js
+++ b/static/js/usCounties.js
@@ -46,6 +46,7 @@ function county_mouseover(e) {
     fillOpacity: 1
   });
   layer.openPopup()
+  info.update(layer.feature.properties);
 }
 
 function county_mouseout(e) {
@@ -54,6 +55,7 @@ function county_mouseout(e) {
     fillOpacity: 0.7
   });
   layer.closePopup()
+	info.update();
 }
 
 // function to remove counties and states when zoom to city
@@ -78,15 +80,17 @@ function zoomToCity(e) {
 function onEachFeature(feature, layer) {
   layer.myTag = "myCounties" // tagging county polygons for removeLayers() function
 
-  var popupContent = "<h4>" + feature.properties.NAME + " County</h4>" +
-    "<table><tr><td>R&B</td><td>" + feature.properties.value * 100 + "%</td></tr>" +
-    "</table>" +
-    "<small>(click to zoom)</small>"
+  var popupContent = 
+  //"<h4>" + feature.properties.NAME + " County</h4>" +
+  //  "<table><tr><td>R&B</td><td>" + feature.properties.value * 100 + "%</td></tr>" +
+  //  "</table>" +
+  "<small>click to see venues in " + feature.properties.NAME +"</small>"; //could just remove popup altogether by commenting out this variable and the below bindPopup function
 
   layer.bindPopup(popupContent, {
     closeButton: false,
     'className': 'custom'
-  }, );
+  },
+  );
 
   layer.on({
     mouseover: county_mouseover,
@@ -139,3 +143,28 @@ usCounties.recalculateGenres = function(genre) {
 }
 
 this.usCounties = usCounties
+
+//from here we're adding a info box to the map to hold the data that was previously in a popup
+
+var info = L.control();
+
+info.onAdd = function (map) {
+    this._div = L.DomUtil.create('div', 'info'); // create a div with a class "info"
+    this.update();
+    return this._div;
+};
+
+info.update = function (props) { // update content of info box
+    this._div.innerHTML = (props ?
+	//start of dynamic content
+	'<h4>' + props.NAME + ' County</h4>' + // county needs to be moved to the attribute value (as not all things are counties
+    //'R&B ' + props.value * 100 + '%' //leaving this here for reference when adding actual values
+	'x'+' '+'pop'+' shows in the next 30 days'+
+	'<br>Population '+'x'+
+	'<br>Rank '+'x'+' of '+'x'
+	//end of dynamic content, next line is default content
+	: 'Hover over a county');
+};
+
+info.addTo(countyMap);
+


### PR DESCRIPTION
Info is now displayed in a fixed div. This applies only to Leaflet, as the D3 map can't have the same solution without covering part of the map.

Values placeholders in the fixed info div are all 'x'